### PR TITLE
Upgrade slogw@v0.1.0 to slogw@0.2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    reviewers:
+      - akm

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/akm/go-requestid
 go 1.21.13
 
 require (
-	github.com/akm/slogw v0.1.0
+	github.com/akm/slogw v0.2.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/akm/slogw v0.1.0 h1:bpHX9Qh661PGtiOWjsR8NBpbbw/agab/g1wScL7M7FU=
 github.com/akm/slogw v0.1.0/go.mod h1:JgLpYS2pVMva5O8CYLqXMRrJ/sS/S5tlhPJLXYaZIZE=
+github.com/akm/slogw v0.2.0 h1:PEJeYiibkH1etRxwQgUgShjdWG0xZD9mtV3/1dlzI90=
+github.com/akm/slogw v0.2.0/go.mod h1:fsifd7vvHAE2L5HFuhrNLl3vd8+MkR+n5Z31BTPPymo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/slog.go
+++ b/slog.go
@@ -9,14 +9,12 @@ import (
 
 func RegisterSlogHandle(key string) {
 	slogw.Register(
-		func(orig slogw.HandleFunc) slogw.HandleFunc {
-			return func(ctx context.Context, rec slog.Record) error {
-				requestID := Get(ctx)
-				if requestID != "" {
-					rec.Add(key, requestID)
-				}
-				return orig(ctx, rec)
+		func(ctx context.Context, rec slog.Record) *slog.Record {
+			requestID := Get(ctx)
+			if requestID != "" {
+				rec.Add(key, requestID)
 			}
+			return &rec
 		},
 	)
 }


### PR DESCRIPTION
- Simplify the function passed to `slogw.Register`
- See https://github.com/akm/slogw/pull/7
